### PR TITLE
Betting commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "fix-lint": "npx eslint --fix --ext .js,.ts src/",
     "start": "node build/index.js",
     "deploy-commands": "node build/commandDeployment.js",
-    "test": "jest --detectOpenHandles --forceExit --silent"
+    "test": "jest --detectOpenHandles --forceExit"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "fix-lint": "npx eslint --fix --ext .js,.ts src/",
     "start": "node build/index.js",
     "deploy-commands": "node build/commandDeployment.js",
-    "test": "jest --detectOpenHandles --forceExit"
+    "test": "jest --detectOpenHandles --forceExit --silent"
   },
   "repository": {
     "type": "git",

--- a/src/models/Bet.ts
+++ b/src/models/Bet.ts
@@ -30,7 +30,7 @@ export class Bet {
         this.winner = params.winner;
     }
 
-    static async create(params: { description: string; optionA: string; optionB: string }) {
+    static async addBet(params: { description: string; optionA: string; optionB: string }) {
         const betKey = betsRef.push().key as string;
         const bet = new Bet({
             id: betKey,
@@ -44,16 +44,16 @@ export class Bet {
         return bet;
     }
 
-    static async findById(id: string) {
+    static async getBet(id: string) {
         const betSnapshot = await betsRef.child(id).once('value');
         return betSnapshot.val();
     }
 
-    static async update(id: string, updates: { status: string; winner: string | null }) {
+    static async updateBet(id: string, updates: { status: string; winner: string | null }) {
         await betsRef.child(id).update(updates);
     }
 
-    static async delete(id: string) {
+    static async deleteBet(id: string) {
         await betsRef.child(id).remove();
     }
 }

--- a/src/models/Bet.ts
+++ b/src/models/Bet.ts
@@ -49,6 +49,11 @@ export class Bet {
         return betSnapshot.val();
     }
 
+    static async getActiveBets() {
+        const betSnapshot = await betsRef.orderByChild('status').equalTo('In Progress').once('value');
+        return betSnapshot.val();
+    }
+
     static async updateBet(id: string, updates: { status: string; winner: string | null }) {
         await betsRef.child(id).update(updates);
     }

--- a/src/models/Bet.ts
+++ b/src/models/Bet.ts
@@ -13,6 +13,8 @@ export class Bet {
     optionB: string;
     status: string;
     winner: string | null;
+    pointsA: number;
+    pointsB: number;
 
     constructor(params: {
         id: string;
@@ -21,6 +23,8 @@ export class Bet {
         optionB: string;
         status: string;
         winner: string | null;
+        pointsA: number;
+        pointsB: number;
     }) {
         this.id = params.id;
         this.description = params.description;
@@ -28,6 +32,8 @@ export class Bet {
         this.optionB = params.optionB;
         this.status = params.status;
         this.winner = params.winner;
+        this.pointsA = params.pointsA;
+        this.pointsB = params.pointsB;
     }
 
     static async addBet(params: { description: string; optionA: string; optionB: string }) {
@@ -39,6 +45,8 @@ export class Bet {
             optionB: params.optionB,
             status: 'In Progress',
             winner: null,
+            pointsA: 0,
+            pointsB: 0,
         });
         await betsRef.child(betKey).set(bet);
         return bet;
@@ -61,4 +69,5 @@ export class Bet {
     static async deleteBet(id: string) {
         await betsRef.child(id).remove();
     }
+
 }

--- a/src/models/Log.ts
+++ b/src/models/Log.ts
@@ -32,7 +32,7 @@ export class Log {
         this.amountWon = params.amountWon;
     }
 
-    static async create(params: { userId: string; betId: string; option: string; amountBet: number }) {
+    static async addRecord(params: { userId: string; betId: string; option: string; amountBet: number }) {
         const logKey = logsRef.push().key as string;
         const log = new Log({
             id: logKey,
@@ -46,16 +46,16 @@ export class Log {
         return log;
     }
 
-    static async findByUserAndBetId(userId: string, betId: string) {
+    static async getRecord(userId: string, betId: string) {
         const logSnapshot = await logsRef.child(`${userId}/${betId}`).once('value');
         return logSnapshot.val();
     }
 
-    static async update(userId: string, betId: string, updates: { amountWon: number }) {
+    static async updateRecord(userId: string, betId: string, updates: { amountWon: number }) {
         await logsRef.child(`${userId}/${betId}`).update(updates);
     }
 
-    static async delete(userId: string, betId: string) {
+    static async deleteRecord(userId: string, betId: string) {
         await logsRef.child(`${userId}/${betId}`).remove();
     }
 }

--- a/src/models/Log.ts
+++ b/src/models/Log.ts
@@ -70,4 +70,9 @@ export class Log {
         });
         return logs;
     }
+
+    static async getRecordsforUser(userId: string) {
+        const logsSnapshot = await logsRef.child(userId).once('value');
+        return logsSnapshot.val();
+    }
 }

--- a/src/models/Log.ts
+++ b/src/models/Log.ts
@@ -58,4 +58,16 @@ export class Log {
     static async deleteRecord(userId: string, betId: string) {
         await logsRef.child(`${userId}/${betId}`).remove();
     }
+
+    static async getRecordsforBet(betId: string) {
+        const logs = [] as Log[];
+        const logsSnapshot = await logsRef.once('value');
+        logsSnapshot.forEach((userSnapshot) => {
+            const userLogs = userSnapshot.val();
+            if (userLogs[betId]) {
+                logs.push(userLogs[betId]);
+            }
+        });
+        return logs;
+    }
 }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -19,7 +19,7 @@ export class User {
         this.points = params.points;
     }
 
-    static async create(params: { discordId: string; username: string; points: number }) {
+    static async addUser(params: { discordId: string; username: string; points: number }) {
         const userKey = usersRef.push().key as string;
         const user = new User({
             id: userKey,
@@ -31,16 +31,17 @@ export class User {
         return user;
     }
 
-    static async findById(id: string) {
+    static async getUser(id: string) {
         const userSnapshot = await usersRef.child(id).once('value');
         return userSnapshot.val();
     }
 
-    static async update(id: string, updates: { points: number }) {
+    static async updateUser(id: string, updates: { points: number }) {
         await usersRef.child(id).update(updates);
     }
 
-    static async delete(id: string) {
+    static async deleteUser(id: string) {
         await usersRef.child(id).remove();
     }
+
 }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -44,4 +44,11 @@ export class User {
         await usersRef.child(id).remove();
     }
 
+    static async addPoints(id: string, points: number) {
+        const user = await this.getUser(id);
+        if (user) {
+            await this.updateUser(id, { points: user.points + points });
+        }
+    }
+
 }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -84,4 +84,18 @@ export class User {
         }
     }
 
+    static async getLeaderboard() {
+        const usersSnapshot = await usersRef.orderByChild('points').limitToLast(10).once('value');
+        const leaderboard: { discordId: string; username: string; points: number }[] = [];
+        usersSnapshot.forEach((userSnapshot) => {
+            leaderboard.push({
+                discordId: userSnapshot.val().discordId,
+                username: userSnapshot.val().username,
+                points: userSnapshot.val().points,
+            });
+        });
+        return leaderboard.reverse();
+    }
+
+
 }

--- a/src/models/utils/distributePoints.ts
+++ b/src/models/utils/distributePoints.ts
@@ -1,0 +1,15 @@
+import { Log } from '../Log';
+
+function distributePoints(logs: Log[], betId: string, totalPoints: number) {
+    // Calculate the total amount bet by all users
+    const totalAmountBet = logs.reduce((acc, log) => acc + log.amountBet, 0);
+
+    // Distribute the points to each user based on their relative share of the total amount bet
+    logs.forEach(log => {
+        log.amountWon = Math.round((log.amountBet / totalAmountBet) * totalPoints);
+    });
+
+    return logs;
+}
+
+export { distributePoints };

--- a/src/models/utils/distributePoints.ts
+++ b/src/models/utils/distributePoints.ts
@@ -5,11 +5,12 @@ function distributePoints(logs: Log[], betId: string, totalPoints: number) {
     const totalAmountBet = logs.reduce((acc, log) => acc + log.amountBet, 0);
 
     // Distribute the points to each user based on their relative share of the total amount bet
-    logs.forEach(log => {
+    const updatedLogs = logs.map(log => {
         log.amountWon = Math.round((log.amountBet / totalAmountBet) * totalPoints);
+        return log;
     });
 
-    return logs;
+    return updatedLogs;
 }
 
 export { distributePoints };

--- a/src/tests/Bet.test.ts
+++ b/src/tests/Bet.test.ts
@@ -36,9 +36,25 @@ describe('update', () => {
         const bet = await Bet.addBet(testBet);
         const updates = { status: 'Closed', winner: 'New England Patriots' };
         await Bet.updateBet(bet.id, updates);
-        const updatedBet = await Bet.findById(bet.id);
+        const updatedBet = await Bet.getBet(bet.id);
         expect(updatedBet.status).toEqual('Closed');
         expect(updatedBet.winner).toEqual('New England Patriots');
         await Bet.deleteBet(bet.id);
+    });
+});
+
+describe('get active bets', () => {
+    it('gets all active bets', async () => {
+        const bet1 = await Bet.addBet(testBet);
+        const bet2 = await Bet.addBet({
+            description: 'Who will win the NBA Finals?',
+            optionA: 'Golden State Warriors',
+            optionB: 'Cleveland Cavaliers',
+        });
+        const activeBets = await Bet.getActiveBets();
+        const activeBetIds = Object.keys(activeBets);
+        expect(activeBetIds).toHaveLength(2);
+        await Bet.deleteBet(bet1.id);
+        await Bet.deleteBet(bet2.id);
     });
 });

--- a/src/tests/Bet.test.ts
+++ b/src/tests/Bet.test.ts
@@ -1,4 +1,4 @@
-import { Bet } from '../models';
+import { Bet, User, Log } from '../models';
 
 const testBet = {
     description: 'Who will win the Super Bowl?',
@@ -34,11 +34,11 @@ describe('findById', () => {
 describe('update', () => {
     it('updates a bet', async () => {
         const bet = await Bet.addBet(testBet);
-        const updates = { status: 'Closed', winner: 'New England Patriots' };
+        const updates = { pointsA: 10, pointsB: 10 };
         await Bet.updateBet(bet.id, updates);
         const updatedBet = await Bet.getBet(bet.id);
-        expect(updatedBet.status).toEqual('Closed');
-        expect(updatedBet.winner).toEqual('New England Patriots');
+        expect(updatedBet.pointsA).toEqual(10);
+        expect(updatedBet.pointsB).toEqual(10);
         await Bet.deleteBet(bet.id);
     });
 });
@@ -56,5 +56,57 @@ describe('get active bets', () => {
         expect(activeBetIds).toHaveLength(2);
         await Bet.deleteBet(bet1.id);
         await Bet.deleteBet(bet2.id);
+    });
+});
+
+describe('Closing bet works correctly', () => {
+    it('closes a bet', async () => {
+        const bet = await Bet.addBet(testBet);
+        await Bet.closeBet(bet.id, 'A');
+        const closedBet = await Bet.getBet(bet.id);
+        expect(closedBet.status).toEqual('Closed');
+        expect(closedBet.winner).toEqual('A');
+        await Bet.deleteBet(bet.id);
+    });
+});
+
+describe('Closing a bet distributes points correctly', () => {
+    it('distributed points correctly', async () => {
+        const user1 = await User.addUser({
+            discordId: '123456789',
+            username: 'testUser1',
+            points: 1000,
+        });
+        const user2 = await User.addUser({
+            discordId: '987654321',
+            username: 'testUser2',
+            points: 1000,
+        });
+        const user3 = await User.addUser({
+            discordId: '123478965',
+            username: 'testUser3',
+            points: 1000,
+        });
+        const bet = await Bet.addBet(testBet);
+        await User.placeBet(user1.id, bet.id, 500, 'A');
+        await User.placeBet(user2.id, bet.id, 100, 'B');
+        await User.placeBet(user3.id, bet.id, 500, 'A');
+        const updatedBet = await Bet.getBet(bet.id);
+        expect(updatedBet.pointsA).toEqual(1000);
+        expect(updatedBet.pointsB).toEqual(100);
+        await Bet.closeBet(bet.id, 'A');
+        const updatedUser1 = await User.getUser(user1.id);
+        const updatedUser2 = await User.getUser(user2.id);
+        const updatedUser3 = await User.getUser(user3.id);
+        expect(updatedUser1.points).toEqual(1050);
+        expect(updatedUser2.points).toEqual(900);
+        expect(updatedUser3.points).toEqual(1050);
+        await User.deleteUser(user1.id);
+        await User.deleteUser(user2.id);
+        await User.deleteUser(user3.id);
+        await Bet.deleteBet(bet.id);
+        await Log.deleteRecord(user1.id, bet.id);
+        await Log.deleteRecord(user2.id, bet.id);
+        await Log.deleteRecord(user3.id, bet.id);
     });
 });

--- a/src/tests/Bet.test.ts
+++ b/src/tests/Bet.test.ts
@@ -8,37 +8,37 @@ const testBet = {
 
 describe('create', () => {
     it('creates a new bet', async () => {
-        const bet = await Bet.create(testBet);
+        const bet = await Bet.addBet(testBet);
         expect(bet.description).toEqual(testBet.description);
         expect(bet.optionA).toEqual(testBet.optionA);
         expect(bet.optionB).toEqual(testBet.optionB);
         expect(bet.status).toEqual('In Progress');
         expect(bet.winner).toBeNull();
-        await Bet.delete(bet.id);
+        await Bet.deleteBet(bet.id);
     });
 });
 
 describe('findById', () => {
     it('finds a bet by its id', async () => {
-        const bet = await Bet.create(testBet);
-        const foundBet = await Bet.findById(bet.id);
+        const bet = await Bet.addBet(testBet);
+        const foundBet = await Bet.getBet(bet.id);
         expect(foundBet.description).toEqual(bet.description);
         expect(foundBet.optionA).toEqual(bet.optionA);
         expect(foundBet.optionB).toEqual(bet.optionB);
         expect(foundBet.status).toEqual(bet.status);
         expect(foundBet.winner).toBeUndefined();
-        await Bet.delete(bet.id);
+        await Bet.deleteBet(bet.id);
     });
 });
 
 describe('update', () => {
     it('updates a bet', async () => {
-        const bet = await Bet.create(testBet);
+        const bet = await Bet.addBet(testBet);
         const updates = { status: 'Closed', winner: 'New England Patriots' };
-        await Bet.update(bet.id, updates);
+        await Bet.updateBet(bet.id, updates);
         const updatedBet = await Bet.findById(bet.id);
         expect(updatedBet.status).toEqual('Closed');
         expect(updatedBet.winner).toEqual('New England Patriots');
-        await Bet.delete(bet.id);
+        await Bet.deleteBet(bet.id);
     });
 });

--- a/src/tests/Log.test.ts
+++ b/src/tests/Log.test.ts
@@ -73,3 +73,20 @@ describe('get records for bet', () => {
         await Log.deleteRecord('123', testBetId);
     });
 });
+
+test('gets all logs for a user', async () => {
+    await Log.addRecord({
+        userId: testUserId,
+        betId: testBetId,
+        ...testLog,
+    });
+    await Log.addRecord({
+        userId: testUserId,
+        betId: '123',
+        ...testLog,
+    });
+    const logs = await Log.getRecordsforUser(testUserId);
+    expect(Object.keys(logs).length).toEqual(2);
+    await Log.deleteRecord(testUserId, testBetId);
+    await Log.deleteRecord(testUserId, '123');
+});

--- a/src/tests/Log.test.ts
+++ b/src/tests/Log.test.ts
@@ -10,7 +10,7 @@ const testLog = {
 
 describe('create', () => {
     it('creates a new log', async () => {
-        const log = await Log.create({
+        const log = await Log.addRecord({
             userId: testUserId,
             betId: testBetId,
             ...testLog,
@@ -20,36 +20,36 @@ describe('create', () => {
         expect(log.option).toEqual(testLog.option);
         expect(log.amountBet).toEqual(testLog.amountBet);
         expect(log.amountWon).toEqual(testLog.amountWon);
-        await Log.delete(testUserId, testBetId);
+        await Log.deleteRecord(testUserId, testBetId);
     });
 });
 
 describe('findByUserAndBetId', () => {
     it('finds a log by its userId and betId', async () => {
-        const log = await Log.create({
+        const log = await Log.addRecord({
             userId: testUserId,
             betId: testBetId,
             ...testLog,
         });
-        const foundLog = await Log.findByUserAndBetId(testUserId, testBetId);
+        const foundLog = await Log.getRecord(testUserId, testBetId);
         expect(foundLog.option).toEqual(log.option);
         expect(foundLog.amountBet).toEqual(log.amountBet);
         expect(foundLog.amountWon).toBeUndefined();
-        await Log.delete(testUserId, testBetId);
+        await Log.deleteRecord(testUserId, testBetId);
     });
 });
 
 describe('update', () => {
     it('updates a log', async () => {
-        await Log.create({
+        await Log.addRecord({
             userId: testUserId,
             betId: testBetId,
             ...testLog,
         });
         const updates = { amountWon: 500 };
-        await Log.update(testUserId, testBetId, updates);
-        const updatedLog = await Log.findByUserAndBetId(testUserId, testBetId);
+        await Log.updateRecord(testUserId, testBetId, updates);
+        const updatedLog = await Log.getRecord(testUserId, testBetId);
         expect(updatedLog.amountWon).toEqual(500);
-        await Log.delete(testUserId, testBetId);
+        await Log.deleteRecord(testUserId, testBetId);
     });
 });

--- a/src/tests/Log.test.ts
+++ b/src/tests/Log.test.ts
@@ -52,4 +52,24 @@ describe('update', () => {
         expect(updatedLog.amountWon).toEqual(500);
         await Log.deleteRecord(testUserId, testBetId);
     });
+
+});
+
+describe('get records for bet', () => {
+    it('gets all logs for a bet', async () => {
+        await Log.addRecord({
+            userId: testUserId,
+            betId: testBetId,
+            ...testLog,
+        });
+        await Log.addRecord({
+            userId: '123',
+            betId: testBetId,
+            ...testLog,
+        });
+        const logs = await Log.getRecordsforBet(testBetId);
+        expect(Object.keys(logs).length).toEqual(2);
+        await Log.deleteRecord(testUserId, testBetId);
+        await Log.deleteRecord('123', testBetId);
+    });
 });

--- a/src/tests/User.test.ts
+++ b/src/tests/User.test.ts
@@ -37,3 +37,13 @@ describe('update', () => {
         await User.deleteUser(user.id);
     });
 });
+
+describe(' Add points to a user\'s balance ', () => {
+    it('adds points to a user', async () => {
+        const user = await User.addUser(testUser);
+        await User.addPoints(user.id, 500);
+        const updatedUser = await User.getUser(user.id);
+        expect(updatedUser.points).toEqual(1500);
+        await User.deleteUser(user.id);
+    });
+});

--- a/src/tests/User.test.ts
+++ b/src/tests/User.test.ts
@@ -8,32 +8,32 @@ const testUser = {
 
 describe('create', () => {
     it('creates a new user', async () => {
-        const user = await User.create(testUser);
+        const user = await User.addUser(testUser);
         expect(user.discordId).toEqual(testUser.discordId);
         expect(user.username).toEqual(testUser.username);
         expect(user.points).toEqual(testUser.points);
-        await User.delete(user.id);
+        await User.deleteUser(user.id);
     });
 });
 
 describe('findById', () => {
     it('finds a user by their id', async () => {
-        const user = await User.create(testUser);
-        const foundUser = await User.findById(user.id);
+        const user = await User.addUser(testUser);
+        const foundUser = await User.getUser(user.id);
         expect(foundUser.discordId).toEqual(user.discordId);
         expect(foundUser.username).toEqual(user.username);
         expect(foundUser.points).toEqual(user.points);
-        await User.delete(user.id);
+        await User.deleteUser(user.id);
     });
 });
 
 describe('update', () => {
     it('updates a user', async () => {
-        const user = await User.create(testUser);
+        const user = await User.addUser(testUser);
         const updates = { points: 500 };
-        await User.update(user.id, updates);
-        const updatedUser = await User.findById(user.id);
+        await User.updateUser(user.id, updates);
+        const updatedUser = await User.getUser(user.id);
         expect(updatedUser.points).toEqual(500);
-        await User.delete(user.id);
+        await User.deleteUser(user.id);
     });
 });

--- a/src/tests/User.test.ts
+++ b/src/tests/User.test.ts
@@ -1,4 +1,4 @@
-import { User } from '../models';
+import { User, Bet, Log } from '../models';
 
 const testUser = {
     discordId: '12345',
@@ -45,5 +45,24 @@ describe(' Add points to a user\'s balance ', () => {
         const updatedUser = await User.getUser(user.id);
         expect(updatedUser.points).toEqual(1500);
         await User.deleteUser(user.id);
+    });
+});
+
+describe(' Place a bet ', () => {
+    it ('places a bet', async () => {
+        const user = await User.addUser(testUser);
+        const bet = await Bet.addBet({
+            description: 'test description',
+            optionA: 'option 1',
+            optionB: 'option 2',
+        });
+        await User.placeBet(user.id, bet.id, 100, 'A');
+        const updatedUser = await User.getUser(user.id);
+        const updatedBet = await Bet.getBet(bet.id);
+        expect(updatedUser.points).toEqual(900);
+        expect(updatedBet.pointsA).toEqual(100);
+        await User.deleteUser(user.id);
+        await Bet.deleteBet(bet.id);
+        await Log.deleteRecord(user.id, bet.id);
     });
 });

--- a/src/tests/User.test.ts
+++ b/src/tests/User.test.ts
@@ -66,3 +66,26 @@ describe(' Place a bet ', () => {
         await Log.deleteRecord(user.id, bet.id);
     });
 });
+
+describe('test leaderboard', () => {
+    it('gets the leaderboard', async () => {
+        const user1 = await User.addUser(testUser);
+        const user2 = await User.addUser({
+            discordId: '123456',
+            username: 'testuser2',
+            points: 500,
+        });
+        const user3 = await User.addUser({
+            discordId: '1234567',
+            username: 'testuser3',
+            points: 2000,
+        });
+        const leaderboard = await User.getLeaderboard();
+        expect(leaderboard[0].discordId).toEqual(user3.discordId);
+        expect(leaderboard[1].discordId).toEqual(user1.discordId);
+        expect(leaderboard[2].discordId).toEqual(user2.discordId);
+        await User.deleteUser(user1.id);
+        await User.deleteUser(user2.id);
+        await User.deleteUser(user3.id);
+    });
+});


### PR DESCRIPTION
This pull request implements the betting functionality for the Discord bot. The following features have been added:

The ability to add a new bet with a description, option A, and option B
The ability to list all current bets that are not closed
The ability for users to place a bet on a specific option
The ability to close a bet and distribute points to users who bet on the winning option
A helper function to distribute points among multiple users based on their bet amount
A method for users to retrieve their own bet logs
A method for retrieving the top 10 users by points
Please note that the slash commands for these features have not yet been implemented.

Changes Made
Added the addBet, listBets, placeBet, and closeBet methods to the Bet model
Added the placeBet method to the User model
Added the distributePoints helper function
Added the getRecordsforUser method to the User model
Added the getTopUsers method to the User model